### PR TITLE
Make compatible with Python 3.7+

### DIFF
--- a/pdbx/reader/PdbxReadWriteTests.py
+++ b/pdbx/reader/PdbxReadWriteTests.py
@@ -170,7 +170,7 @@ class PdbxReadWriteTests(unittest.TestCase):
             myBlock.printIt()
             myCat=myBlock.getObj('pdbx_seqtool_mapping_ref')
             myCat.printIt()
-            for iRow in xrange(0,myCat.getRowCount()):
+            for iRow in range(0,myCat.getRowCount()):
                 myCat.setValue('some value', 'ref_mon_id',iRow)
                 myCat.setValue(100, 'ref_mon_num',iRow)
             ofh = open("test-output-2.cif", "w")            

--- a/pdbx/reader/PdbxReader.py
+++ b/pdbx/reader/PdbxReader.py
@@ -355,7 +355,10 @@ class PdbxReader(object):
 
         ## Tokenizer loop begins here ---
         while True:
-            line = next(fileIter)
+            try:
+                line = next(fileIter)
+            except StopIteration:
+                break
             self.__curLineNumber += 1
 
             # Dump comments

--- a/pdbx/writer/PdbxWriterTests.py
+++ b/pdbx/writer/PdbxWriterTests.py
@@ -109,7 +109,7 @@ class PdbxWriterTests(unittest.TestCase):
             myBlock.printIt()
             myCat=myBlock.getObj('pdbx_seqtool_mapping_ref')
             myCat.printIt()
-            for iRow in xrange(0,myCat.getRowCount()):
+            for iRow in range(0,myCat.getRowCount()):
                 myCat.setValue('some value', 'ref_mon_id',iRow)
                 myCat.setValue(100, 'ref_mon_num',iRow)
             ofh = open("test-output-2.cif", "w")            


### PR DESCRIPTION
Hello!

Starting with Python 3.7, the [PEP-479](https://www.python.org/dev/peps/pep-0479/) is now always enabled. This broke the `__tokenizer` function, used internally in PdbxReader: now at the end of the file a RuntimeException is raised.

In this PR, explicit handling of `StopIteration` is added.
Also, two `xrange`s were changed to `range`. The README of the project specifies Python 3 as a requirement, so I believe this should be fine without any additional code for Python 2 support (and the arrays in question does not seem big, so, even on Python 2, the `range` should be fine).